### PR TITLE
[ADD][ADDITIONAL] class-based class01

### DIFF
--- a/python/classbased/class01.ipynb
+++ b/python/classbased/class01.ipynb
@@ -200,13 +200,13 @@
      "evalue": "Interrupted by user",
      "output_type": "error",
      "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-4-3f52d42580fc>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      4\u001b[0m     \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mstr_a\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m-\u001b[0m \u001b[0mint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mstr_b\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 6\u001b[1;33m \u001b[0msubtract_b_from_a\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32m<ipython-input-4-3f52d42580fc>\u001b[0m in \u001b[0;36msubtract_b_from_a\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0msubtract_b_from_a\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m     \u001b[0minput_a_b\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0minput\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      3\u001b[0m     \u001b[0mstr_a\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mstr_b\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0minput_a_b\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msplit\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m' '\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m     \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mstr_a\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m-\u001b[0m \u001b[0mint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mstr_b\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\ipykernel\\kernelbase.py\u001b[0m in \u001b[0;36mraw_input\u001b[1;34m(self, prompt)\u001b[0m\n\u001b[0;32m    858\u001b[0m                 \u001b[1;34m\"raw_input was called, but this frontend does not support input requests.\"\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    859\u001b[0m             )\n\u001b[1;32m--> 860\u001b[1;33m         return self._input_request(str(prompt),\n\u001b[0m\u001b[0;32m    861\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_parent_ident\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    862\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_parent_header\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\lib\\site-packages\\ipykernel\\kernelbase.py\u001b[0m in \u001b[0;36m_input_request\u001b[1;34m(self, prompt, ident, parent, password)\u001b[0m\n\u001b[0;32m    902\u001b[0m             \u001b[1;32mexcept\u001b[0m \u001b[0mKeyboardInterrupt\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    903\u001b[0m                 \u001b[1;31m# re-raise KeyboardInterrupt, to truncate traceback\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 904\u001b[1;33m                 \u001b[1;32mraise\u001b[0m \u001b[0mKeyboardInterrupt\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Interrupted by user\"\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    905\u001b[0m             \u001b[1;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    906\u001b[0m                 \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwarning\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Invalid Message:\"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mexc_info\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mKeyboardInterrupt\u001b[0m: Interrupted by user"
+      "\u001B[1;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[1;31mKeyboardInterrupt\u001B[0m                         Traceback (most recent call last)",
+      "\u001B[1;32m<ipython-input-4-3f52d42580fc>\u001B[0m in \u001B[0;36m<module>\u001B[1;34m\u001B[0m\n\u001B[0;32m      4\u001B[0m     \u001B[0mprint\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mint\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mstr_a\u001B[0m\u001B[1;33m)\u001B[0m \u001B[1;33m-\u001B[0m \u001B[0mint\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mstr_b\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m      5\u001B[0m \u001B[1;33m\u001B[0m\u001B[0m\n\u001B[1;32m----> 6\u001B[1;33m \u001B[0msubtract_b_from_a\u001B[0m\u001B[1;33m(\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[1;32m<ipython-input-4-3f52d42580fc>\u001B[0m in \u001B[0;36msubtract_b_from_a\u001B[1;34m()\u001B[0m\n\u001B[0;32m      1\u001B[0m \u001B[1;32mdef\u001B[0m \u001B[0msubtract_b_from_a\u001B[0m\u001B[1;33m(\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m:\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[1;32m----> 2\u001B[1;33m     \u001B[0minput_a_b\u001B[0m \u001B[1;33m=\u001B[0m \u001B[0minput\u001B[0m\u001B[1;33m(\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0m\u001B[0;32m      3\u001B[0m     \u001B[0mstr_a\u001B[0m\u001B[1;33m,\u001B[0m \u001B[0mstr_b\u001B[0m \u001B[1;33m=\u001B[0m \u001B[0minput_a_b\u001B[0m\u001B[1;33m.\u001B[0m\u001B[0msplit\u001B[0m\u001B[1;33m(\u001B[0m\u001B[1;34m' '\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m      4\u001B[0m     \u001B[0mprint\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mint\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mstr_a\u001B[0m\u001B[1;33m)\u001B[0m \u001B[1;33m-\u001B[0m \u001B[0mint\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mstr_b\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m      5\u001B[0m \u001B[1;33m\u001B[0m\u001B[0m\n",
+      "\u001B[1;32m~\\anaconda3\\lib\\site-packages\\ipykernel\\kernelbase.py\u001B[0m in \u001B[0;36mraw_input\u001B[1;34m(self, prompt)\u001B[0m\n\u001B[0;32m    858\u001B[0m                 \u001B[1;34m\"raw_input was called, but this frontend does not support input requests.\"\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m    859\u001B[0m             )\n\u001B[1;32m--> 860\u001B[1;33m         return self._input_request(str(prompt),\n\u001B[0m\u001B[0;32m    861\u001B[0m             \u001B[0mself\u001B[0m\u001B[1;33m.\u001B[0m\u001B[0m_parent_ident\u001B[0m\u001B[1;33m,\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m    862\u001B[0m             \u001B[0mself\u001B[0m\u001B[1;33m.\u001B[0m\u001B[0m_parent_header\u001B[0m\u001B[1;33m,\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n",
+      "\u001B[1;32m~\\anaconda3\\lib\\site-packages\\ipykernel\\kernelbase.py\u001B[0m in \u001B[0;36m_input_request\u001B[1;34m(self, prompt, ident, parent, password)\u001B[0m\n\u001B[0;32m    902\u001B[0m             \u001B[1;32mexcept\u001B[0m \u001B[0mKeyboardInterrupt\u001B[0m\u001B[1;33m:\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m    903\u001B[0m                 \u001B[1;31m# re-raise KeyboardInterrupt, to truncate traceback\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[1;32m--> 904\u001B[1;33m                 \u001B[1;32mraise\u001B[0m \u001B[0mKeyboardInterrupt\u001B[0m\u001B[1;33m(\u001B[0m\u001B[1;34m\"Interrupted by user\"\u001B[0m\u001B[1;33m)\u001B[0m \u001B[1;32mfrom\u001B[0m \u001B[1;32mNone\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0m\u001B[0;32m    905\u001B[0m             \u001B[1;32mexcept\u001B[0m \u001B[0mException\u001B[0m \u001B[1;32mas\u001B[0m \u001B[0me\u001B[0m\u001B[1;33m:\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m    906\u001B[0m                 \u001B[0mself\u001B[0m\u001B[1;33m.\u001B[0m\u001B[0mlog\u001B[0m\u001B[1;33m.\u001B[0m\u001B[0mwarning\u001B[0m\u001B[1;33m(\u001B[0m\u001B[1;34m\"Invalid Message:\"\u001B[0m\u001B[1;33m,\u001B[0m \u001B[0mexc_info\u001B[0m\u001B[1;33m=\u001B[0m\u001B[1;32mTrue\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n",
+      "\u001B[1;31mKeyboardInterrupt\u001B[0m: Interrupted by user"
      ]
     }
    ],
@@ -1321,6 +1321,105 @@
     "printout_a_X_b()"
    ],
    "id": "bdfc4f390981adf2"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "알파벳 소문자, 대문자, 숫자 0-9중 하나가 주어졌을 때, 주어진 글자의 아스키 코드값을 출력하는 프로그램을 작성하시오.\n",
+    "\n",
+    "입력\n",
+    "알파벳 소문자, 대문자, 숫자 0-9 중 하나가 첫째 줄에 주어진다.\n",
+    "\n",
+    "출력\n",
+    "입력으로 주어진 글자의 아스키 코드 값을 출력한다."
+   ],
+   "id": "e061dabc74c97ade"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T13:07:14.977601Z",
+     "start_time": "2024-12-04T13:07:11.535998Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def printout_ascii_code():\n",
+    "    print(ord(input())) \n",
+    "\n",
+    "printout_ascii_code()"
+   ],
+   "id": "90f1a5c28ba2e596",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "65\n"
+     ]
+    }
+   ],
+   "execution_count": 8
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "아래 예제와 같이 새싹을 출력하시오.\n",
+    "\n",
+    "입력\n",
+    "입력은 없다.\n",
+    "\n",
+    "출력\n",
+    "새싹을 출력한다.\n",
+    "\n",
+    "         ,r'\"7\n",
+    "r`-_   ,'  ,/\n",
+    " \\. \". L_r'\n",
+    "   `~\\/\n",
+    "      |\n",
+    "      |"
+   ],
+   "id": "51a9c42fc24e977f"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-04T13:12:34.293870Z",
+     "start_time": "2024-12-04T13:12:34.289992Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def printout_plant():\n",
+    "    print(\"\"\"         ,r'\"7\\nr`-_   ,'  ,/\\n \\\\. \". L_r'\\n   `~\\\\/\\n      |\\n      |\"\"\")\n",
+    "    \n",
+    "    \n",
+    "printout_plant()"
+   ],
+   "id": "1f75ab49de9fac7",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         ,r'\"7\n",
+      "r`-_   ,'  ,/\n",
+      " \\. \". L_r'\n",
+      "   `~\\/\n",
+      "      |\n",
+      "      |\n"
+     ]
+    }
+   ],
+   "execution_count": 10
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "",
+   "id": "f362a2de663a069b"
   }
  ],
  "metadata": {


### PR DESCRIPTION
25083 새싹 문제의  정답 목록에 
```
print(
"""         ,r'"7
r`-_   ,'  ,/
 \. ". L_r'
   `~\/
      |
      |""")
```
와 같은 부분이 있었다.

이 구문은 python 3.12.5에서 SyntaxWarning을 콘솔에 띄웠다.

deprecated 패치에 따라서 이후의 버전이 SyntaxWarning을 일으키는 경우가 있다.

이를 코드 작성 시에 주의해야겠다.

compared -> my version

```
def printout_plant():
    print("""         ,r'"7\nr`-_   ,'  ,/\n \\. ". L_r'\n   `~\\/\n      |\n      |""")


printout_plant()
```

유사한 사례로 이가 있다.


```
a=int(input())
e=int(input())
if(a>=3and e<=4):
    print("TroyMartian")
if(a<=6and e>=2):
    print("VladSaturnian")
if(a<=2and e<=3):
    print("GraemeMercurian")
```

![image](https://github.com/user-attachments/assets/75e94a86-0d45-4e6a-aef8-05836158ffa8)


> 제 코드는 아니지만 integer뒤에 keyword가 오는 경우는 Python 3.10부터 Deprecated되었고, 3.11부터 SyntaxWarning이 표시된다고 하더라구요 Python 실행 옵션을 변경하여 다음과 같이 실행하면 SyntaxWarning이 stderror로 나타나지 않습니다

`python -W ignore Main.py`